### PR TITLE
Added setters for date and time fields

### DIFF
--- a/Chronodot.h
+++ b/Chronodot.h
@@ -19,6 +19,14 @@ public:
     uint8_t hour() const        { return hh; }
     uint8_t minute() const      { return mm; }
     uint8_t second() const      { return ss; }
+	
+    void setYear(uint16_t y)       { yOff = y - 2000; }
+    void setMonth(uint8_t m)       { this->m = m; }
+    void setDay(uint8_t d)         { this->d = d; }
+    void setHour(uint8_t hh)       { this->hh = hh; }
+    void setMinute(uint8_t mm)     { this->mm = mm; }
+    void setSecond(uint8_t ss)     { this->ss = ss; }
+	
     int tempF() const			{ return ttf; }
     float tempC() const			{ return ttc; }
     uint8_t dayOfWeek() const;

--- a/README
+++ b/README
@@ -9,6 +9,9 @@ Examples are provided.
 
 Changelog:
 
+May 2012:	Added public setters for year, month, day, hour, second and second.
+		This allows updating a DateTime object in preparation for a call to
+		Chronodot.adjust (e.g. in response to user input to set date/time)
 February 2012:  Fixed bug in isRunning function - was checking 
 				the wrong register!
 				Fixed variable type error - was using unsigned


### PR DESCRIPTION
Is DateTime intentionally immutable?
Maybe i'm missing something but I couldn't find any way to set the individual fields of a DateTime object.

What is the recommended way to set the datetime on the chronodot while using a keypad for input.
I had considered updating an epoch timestamp as digits are input, but that's a pain in the arse!
It's just easier to use a mutable DateTime object.

Of course i could reconstruct a new DateTime on every keypress but that seems wasteful.

In mobile app development, the accepted paradigm is actually to provide public member fields rather than access thru getters/setters to avoid the method call overhead. It seems that paradigm should be even more applicable to firmware development.
